### PR TITLE
devCommand: run config only if exists

### DIFF
--- a/stackbit.yaml
+++ b/stackbit.yaml
@@ -4,7 +4,7 @@ nodeVersion: '16'
 
 ssgName: custom
 buildCommand: npm run build
-devCommand: npm run config && ./node_modules/.bin/ng serve  --port {PORT} --disable-host-check
+devCommand: npm run config --if-present && ./node_modules/.bin/ng serve  --port {PORT} --disable-host-check
 
 publishDir: dist
 experimental:


### PR DESCRIPTION
@stackbitjoe when you create an "official" Angular profile we have to make sure it doesn't run scripts which may not exist in all repo's. 
So since getting environment variables into the build is a real need, I suggest the devCommand will attmpt to run "config" only if exists, and I will now document that.